### PR TITLE
Create a workflow for generating documentation with Javadoc

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -33,5 +33,24 @@ jobs:
     - name: Upload the Javadoc output
       uses: actions/upload-artifact@v2
       with:
-        name: Javadoc-output
+        name: javadoc-output
         path: ./javadoc-output/
+
+    - name: Commit and push new Javadoc folder
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "actions@github.com"
+        mv javadoc-output/ ..
+        git remote set-branches origin '*'
+        git fetch -v
+        git checkout gh-pages
+        rm -r javadoc/
+        mv ../javadoc-output/ ./javadoc/
+        git add .
+        git commit -a -m "Javadoc documentation update ($GITHUB_RUN_NUMBER)
+          Information:
+          Repository: $GITHUB_REPOSITORY
+          Branch: $GITHUB_REF
+          Commit: $GITHUB_SHA
+          Who triggered action: $GITHUB_ACTOR"
+        git push

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Upload the Javadoc output
       uses: actions/upload-artifact@v2
       with:
-        name: javadoc-output
+        name: Javadoc-output
         path: ./javadoc-output/
 
     - name: Commit and push new Javadoc folder
@@ -41,11 +41,17 @@ jobs:
         git config user.name "GitHub Actions Bot"
         git config user.email "actions@github.com"
         mv javadoc-output/ ..
+        mv ./TeamCode/build/reports/  ..
+        mkdir ../sdk-reports/
+        mv ./FtcRobotController/build/reports/* ../sdk-reports/
         git remote set-branches origin '*'
         git fetch -v
         git checkout gh-pages
-        rm -r javadoc/
+        rm -rf javadoc/ || true
         mv ../javadoc-output/ ./javadoc/
+        rm -rf reports/ || true
+        mv ../reports/ .
+        mv ../sdk-reports/ ./reports/sdk-reports
         git add .
         git commit -a -m "Javadoc documentation update ($GITHUB_RUN_NUMBER)
           Information:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,37 @@
+name: Javadoc Generation
+on:
+  push:
+    branches: master
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up the JDK environment
+      uses: actions/setup-java@v2
+      with:
+        java-version: 16
+        distribution: 'adopt'
+        cache: gradle
+
+    - name: Gradle version
+      run: ./gradlew --version
+
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
+
+    - name: Generate documentation with Javadoc
+      run: javadoc -d javadoc-output $(find . -name "*.java") -Xdoclint:none --ignore-source-errors
+
+    - name: Upload the Javadoc output
+      uses: actions/upload-artifact@v2
+      with:
+        name: Javadoc-output
+        path: ./javadoc-output/


### PR DESCRIPTION
This action builds the project and uses Javadoc to generate documentation for the project if the build succeeds.
Adding the Javadoc output to the `gh-pages` branch is currently not implemented but is planned.
Note that this action only runs when code is pushed to the `master` branch to reduce the number of commits that will be made to the `gh-pages` branch, but this action can also be run manually.
Unfortunately, the only way that I could find to get Javadoc to work requires a hack that involves using a command-line switch to ignore errors.

I believe that the workflow is now finished.

My plans:

- [x] Commit the Javadoc output to the `gh-pages` branch.
- [x] Upload the build lint results to the `gh-pages` branch.
- [x] Find a way of running Javadoc without the `-Xdoclint:none --ignore-source-errors` hack. [Apparently not possible]
- [x] Prepare the `gh-pages` branch for the action's first run.