### PR TITLE
Attempt to fix the javadoc error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /**
  * Top-level build file for ftc_app project.
  *
- * It is extraordinarily rare that you will ever need to edit this file.
+ * It is extraordinarily rare that you will ever need to edit this file. (no, no its not -thomas ricci)
  */
 
 configurations {
@@ -74,5 +74,10 @@ task extractJavadoc {
             }
         }
     }
+}
+
+task docs(type: Javadoc) {
+    classpath = project.sourceSets.main.runtimeClasspath
+    source = sourceSets.main.allJava
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@
  * It is extraordinarily rare that you will ever need to edit this file. (no, no its not -thomas ricci)
  */
 
+apply plugin: 'java'
+
 configurations {
     doc { transitive false }
 }


### PR DESCRIPTION
@MatthewL246 I think this should fix the Javadoc generation. We just need to change
```yaml
- name: Generate documentation with Javadoc
        run:
          javadoc -d javadoc-output $(find . -name "*.java") -Xdoclint:none
          --ignore-source-errors
```
in javadoc.yml to something like
```yaml
- name: Generate documentation with Javadoc
        run:
          gradle docs
```
Could you test this on your fork? You'll need to reference a dependency from inside the code, for example make a documented method like:
```java
/**
* @param opMode some message
*/
public void method(LinearOpMode opMode) {}
```
That should force the generator to index a dependency, and if it works it should be fixed.