### PR TITLE
Add documentation comments to opmodes and features

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ActuatorTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ActuatorTest.java
@@ -8,6 +8,7 @@ import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Loggers;
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 
 /**
+ * Test basic servo actuator functions.
  * Uses servo port 2.
  * Square = Down
  * Cross = Up

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
@@ -14,6 +14,10 @@ import static java.lang.String.format;
 import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging.log;
 import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging.logData;
 
+/**
+ * Test the AprilTag detector feature and log detection info.
+ * Requires a camera.
+ */
 public class ApriltagDetectionTest extends OperationMode implements TeleOperation {
     AprilTagDetector detector;
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
@@ -8,6 +8,10 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
+/**
+ * Drive towards an AprilTag target.
+ * Requires a camera.
+ */
 public class DriveTowardsAprilTag extends OperationMode implements TeleOperation {
     MecanumDriver driver;
     AprilTagDetector detector;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
@@ -5,6 +5,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
 /**
+ * Test the four motor arm with controller2.
  * Uses motors 4-7 and encoders 5-6
  * Use controller2's triggers to control the arm.
  * Use controller2's sticks to control each side of the arm independently

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/IMU_CSV_Logger.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/IMU_CSV_Logger.java
@@ -9,6 +9,9 @@ import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 import java.io.File;
 import java.util.ArrayList;
 
+/**
+ * Log acceleration and gyro data from the IMU and write it to imu_data.csv.
+ */
 public class IMU_CSV_Logger extends OperationMode implements TeleOperation {
     public ArrayList<ArrayList<Double>> history = new ArrayList<>();
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
@@ -4,6 +4,10 @@ import org.firstinspires.ftc.teamcode.features.Lifter;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Test the robot screw lifter feature.
+ * Uses controller1 and motor0.
+ */
 public class LifterTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
@@ -4,6 +4,10 @@ import org.firstinspires.ftc.teamcode.features.LinearSlide;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Test the linear slide feature.
+ * Uses motor4 (controller1 trigger buttons) and motor5 (controller1 right stick y axis).
+ */
 public class LinearSlideTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
@@ -4,6 +4,10 @@ import org.firstinspires.ftc.teamcode.features.PixelGrabber;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Tests the manual pixel grabber.
+ * Uses controller1's left and right bumpers to control servo0 and servo1.
+ */
 public class PixelGrabberTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SingleMotorTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SingleMotorTest.java
@@ -4,6 +4,9 @@ import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Tests running a single motor0 with controller1's left and right trigger buttons.
+ */
 public class SingleMotorTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {


### PR DESCRIPTION
I will add documentation comments to the opmodes and features.

I think each opmode comment should have a short description and links to the features used, and each feature comment should have a short description, requirements for attached devices, and controls.