### PR TITLE
Add documentation comments to opmodes and features

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/ActuatorFeature.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/ActuatorFeature.java
@@ -1,18 +1,16 @@
 package org.firstinspires.ftc.teamcode.features;
 
-import org.firstinspires.ftc.teamcode.internals.features.Buildable;
 import org.firstinspires.ftc.teamcode.internals.features.Feature;
 import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
-import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
-import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
-import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 
 /**
- * Uses servo port 2.
- * Square = Down
- * Cross = Up
+ * This is a simple test for the servo controls.
+ * <p>
+ * Connections: A servo in port 2 and a controller.
+ * <p>
+ * Controls: Hold the square button to move down or the cross button to move up.
  */
-public class ActuatorFeature extends Feature{
+public class ActuatorFeature extends Feature {
 
     @Override
     public void loop() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/AirplaneLauncher.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/AirplaneLauncher.java
@@ -6,8 +6,11 @@ import org.firstinspires.ftc.teamcode.internals.features.Feature;
 import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 
 /**
- * Uses servo 4
- * Dpad up - launch
+ * This sets up the airplane launcher servo and uses it to launch the plane.
+ * <p>
+ * Connections: A servo in port 4 and a controller.
+ * <p>
+ * Controls: Press up on the dpad to launch the plane.
  */
 public class AirplaneLauncher extends Feature implements Buildable {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/AprilTagDetector.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/AprilTagDetector.java
@@ -12,10 +12,17 @@ import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
 
 import java.util.List;
 
+/**
+ * This detects AprilTags and shows them on the FTC dashboard.
+ * <p>
+ * Connections: A camera and a computer connected to the dashboard.
+ * <p>
+ * Controls: Uses the dashboard.
+ */
 public class AprilTagDetector extends Feature implements Buildable {
+    public List<AprilTagDetection> currentDetections;
     AprilTagProcessor aprilTag;
     VisionPortal vision;
-    public List<AprilTagDetection> currentDetections;
     CameraName cameraName;
 
     public AprilTagDetector(CameraName cameraName) {
@@ -41,7 +48,9 @@ public class AprilTagDetector extends Feature implements Buildable {
         currentDetections = aprilTag.getDetections();
     }
 
-    public List<AprilTagDetection> getCurrentDetections() { return currentDetections; }
+    public List<AprilTagDetection> getCurrentDetections() {
+        return currentDetections;
+    }
 
     public void stop() {
         vision.setProcessorEnabled(aprilTag, false);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/FourMotorArm.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/FourMotorArm.kt
@@ -8,7 +8,27 @@ import org.firstinspires.ftc.teamcode.internals.hardware.Devices.Companion.contr
 import org.firstinspires.ftc.teamcode.internals.motion.pid.basic.BasicPositionInputFilter
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.DSLogging
 
-class FourMotorArm: Feature(), Buildable {
+/**
+ * This controls the motors for the double reverse four-bar linkage system. Used for both the
+ * autonomous and TeleOp modes.
+ * <p>
+ * Connections: Motors in ports 4 (top) and 5 (bottom) for the left side and 6 (top) and 7 (bottom)
+ * for the right side. Also needs 2 connected controllers.
+ * <p>
+ * Controls:
+ * Controller 2: Hold the right trigger to move up or the left trigger to move down. If the right
+ * and left sides become misaligned, push the right stick up to move the right side up or down to
+ * move it down (same for the left side using the left stick).
+ * <p>
+ * You can also use gamepad buttons to automatically move the arm to the correct position. Use
+ * triangle for a high junction, circle for a medium junction, square for a low junction, cross for
+ * a ground junction, dpad left for a single cone, dpad right for a stack of 3 cones, dpad up for a
+ * stack of 5 cones, or dpad down to move to ground level. Press share to attempt to automatically
+ * level the arm.
+ * <p>
+ * Both controllers: Press any bumper to immediately cancel the auto-move.
+ */
+class FourMotorArm : Feature(), Buildable {
 
     override fun build() {
         Devices.encoder5.reset()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/FourMotorArmNoManualLevel.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/FourMotorArmNoManualLevel.kt
@@ -8,7 +8,12 @@ import org.firstinspires.ftc.teamcode.internals.hardware.Devices.Companion.contr
 import org.firstinspires.ftc.teamcode.internals.motion.pid.basic.BasicPositionInputFilter
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.DSLogging
 
-class FourMotorArmNoManualLevel: Feature(), Buildable {
+/**
+ * Same as @see FourMotorArm but controller 1 can manually move the arm with the trigger buttons,
+ * while 2 can only set the automatic positions. Controller 1 can also manually level the arm by
+ * moving down the left side with the square button or the right side with the circle button.
+ */
+class FourMotorArmNoManualLevel : Feature(), Buildable {
 
     override fun build() {
         Devices.encoder5.reset()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/FourMotorArmNoManualLevel.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/FourMotorArmNoManualLevel.kt
@@ -9,7 +9,7 @@ import org.firstinspires.ftc.teamcode.internals.motion.pid.basic.BasicPositionIn
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.DSLogging
 
 /**
- * Same as @see FourMotorArm but controller 1 can manually move the arm with the trigger buttons,
+ * Same as {@link org.firstinspires.ftc.features.FourMotorArm} but controller 1 can manually move the arm with the trigger buttons,
  * while 2 can only set the automatic positions. Controller 1 can also manually level the arm by
  * moving down the left side with the square button or the right side with the circle button.
  */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/Hand.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/Hand.kt
@@ -8,6 +8,11 @@ import org.firstinspires.ftc.teamcode.internals.time.Clock
 import org.firstinspires.ftc.teamcode.internals.time.Timer
 import java.util.*
 
+/**
+ * This controls the cone grabber hand.
+ * Connections: Left servo in port 1, right servo in port 0, and a controller.
+ * Controls: Press the y button to close the hand or the a button to open it.
+ */
 class Hand() : Feature(), Buildable {
 
     private var auto = false

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/Lifter.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/Lifter.java
@@ -4,7 +4,7 @@ import org.firstinspires.ftc.teamcode.internals.features.Feature;
 import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 
 /**
- * This is a test for a single motor.
+ * This is a test the robot screw lifter.
  * <p>
  * Connections: A motor in port 0 and a controller.
  * <p>

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/Lifter.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/Lifter.java
@@ -3,6 +3,13 @@ package org.firstinspires.ftc.teamcode.features;
 import org.firstinspires.ftc.teamcode.internals.features.Feature;
 import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 
+/**
+ * This is a test for a single motor.
+ * <p>
+ * Connections: A motor in port 0 and a controller.
+ * <p>
+ * Controls: Move the left stick up and down to control the motor.
+ */
 public class Lifter extends Feature {
     @Override
     public void loop() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/LinearSlide.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/LinearSlide.java
@@ -4,9 +4,13 @@ import org.firstinspires.ftc.teamcode.internals.features.Feature;
 import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 
 /**
- * Uses motor 4
- * Right trigger - raise
- * Left trigger - lower
+ * This controls a linear slide and an extra motor.
+ * <p>
+ * Connections: A motor connected to the linear slide in port 4 and a controller. Also uses motor in
+ * port 5.
+ * <p>
+ * Controls: Use the right trigger to raise the slide and the left trigger to lower it. Move the
+ * right stick up or down to control the motor in port 5.
  */
 public class LinearSlide extends Feature {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/NativeMecanumDrivetrain.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/NativeMecanumDrivetrain.kt
@@ -9,7 +9,12 @@ import org.firstinspires.ftc.teamcode.internals.misc.MecanumDriver
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging
 
 /**
-* A mecanum drivetrain&mdash;this doesn't require odometry, hence it being "native" by not relying on external libraries. If you have odometry, use MecanumDrivetrain
+* A mecanum drivetrain&mdash;this doesn't require odometry, hence it being "native" by not relying
+ * on external libraries. If you have odometry, use MecanumDrivetrain.
+ * <p>
+ * Controls: Right joystick controlls rotation. Left joystick controlls forward/backward/left/right
+ * movement. Controller 1 has full power. Controller 2 has reduced power (for finer control)
+ * <p>
  * @param drivetrainMapMode The motor layout of the drivetrain.
  * @param useExpansionHub Whether or not to use the expansion hub to get the motors. Requires that the expansion hub motors be initialized before use
  * @param fieldCentric Whether or not to use field centric controls. The imu must be initialized prior to use.
@@ -53,14 +58,6 @@ class NativeMecanumDrivetrain(
     }
 
     override fun loop() {
-        /*
-        Right joystick controlls rotation
-        Left joystick controlls forward/backward/left/right movement
-
-        Controller 1 has full power
-        Controller 2 has reduced power (for finer control)
-         */
-
         var rot: Double = if (!isRotInverted) {
             CONTROL1_ROTATIONAL_MOTION * controller1.rightStickX + CONTROL2_ROTATIONAL_MOTION * controller2.rightStickX
         } else {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/PixelGrabber.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/features/PixelGrabber.java
@@ -5,8 +5,11 @@ import org.firstinspires.ftc.teamcode.internals.features.Feature;
 import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 
 /**
- * Right servo = port 0
- * Left servo = port 1
+ * This controls the pixel grabber.
+ * <p>
+ * Connections: Uses the right servo in port 0, the left servo in port 1, and a controller.
+ * <p>
+ * Controls: Use the right bumper to close the grabber or the left bumper to open it.
  */
 public class PixelGrabber extends Feature implements Buildable {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
@@ -14,6 +14,10 @@ import static java.lang.String.format;
 import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging.log;
 import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging.logData;
 
+/**
+ * Test the AprilTag detector feature and log detection info.
+ * Requires a camera.
+ */
 public class ApriltagDetectionTest extends OperationMode implements TeleOperation {
     AprilTagDetector detector;
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
@@ -17,7 +17,7 @@ import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging
 /**
  * This tests the AprilTag detector and logs detection info.
  * <p>
- * Features: @see AprilTagDetector
+ * Features: {@link org.firstinspires.ftc.teamcode.features.AprilTagDetector}
  */
 public class ApriltagDetectionTest extends OperationMode implements TeleOperation {
     AprilTagDetector detector;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/ApriltagDetectionTest.java
@@ -15,8 +15,9 @@ import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging
 import static org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging.logData;
 
 /**
- * Test the AprilTag detector feature and log detection info.
- * Requires a camera.
+ * This tests the AprilTag detector and logs detection info.
+ * <p>
+ * Features: @see AprilTagDetector
  */
 public class ApriltagDetectionTest extends OperationMode implements TeleOperation {
     AprilTagDetector detector;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
@@ -11,7 +11,7 @@ import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 /**
  * This drives towards an AprilTag target.
  * <p>
- * Features: @see AprilTagDetector
+ * Features: {@link org.firstinspires.ftc.teamcode.features.AprilTagDetector}
  */
 public class DriveTowardsAprilTag extends OperationMode implements TeleOperation {
     MecanumDriver driver;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
@@ -8,6 +8,10 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
+/**
+ * Drive towards an AprilTag target.
+ * Requires a camera.
+ */
 public class DriveTowardsAprilTag extends OperationMode implements TeleOperation {
     MecanumDriver driver;
     AprilTagDetector detector;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/DriveTowardsAprilTag.java
@@ -9,8 +9,9 @@ import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
 /**
- * Drive towards an AprilTag target.
- * Requires a camera.
+ * This drives towards an AprilTag target.
+ * <p>
+ * Features: @see AprilTagDetector
  */
 public class DriveTowardsAprilTag extends OperationMode implements TeleOperation {
     MecanumDriver driver;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
@@ -7,7 +7,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 /**
  * This tests the double reverse four-bar linkage system.
  * <p>
- * Features: @see FourMotorArm
+ * Features: {@link org.firstinspires.ftc.teamcode.features.FourMotorArm}
  */
 public class FourArmTest extends OperationMode implements TeleOperation {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
@@ -5,6 +5,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
 /**
+ * Test the four motor arm with controller2.
  * Uses motors 4-7 and encoders 5-6
  * Use controller2's triggers to control the arm.
  * Use controller2's sticks to control each side of the arm independently

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/FourArmTest.java
@@ -5,10 +5,9 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
 /**
- * Test the four motor arm with controller2.
- * Uses motors 4-7 and encoders 5-6
- * Use controller2's triggers to control the arm.
- * Use controller2's sticks to control each side of the arm independently
+ * This tests the double reverse four-bar linkage system.
+ * <p>
+ * Features: @see FourMotorArm
  */
 public class FourArmTest extends OperationMode implements TeleOperation {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/IMU_CSV_Logger.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/IMU_CSV_Logger.java
@@ -9,6 +9,9 @@ import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 import java.io.File;
 import java.util.ArrayList;
 
+/**
+ * Log acceleration and gyro data from the IMU and write it to imu_data.csv.
+ */
 public class IMU_CSV_Logger extends OperationMode implements TeleOperation {
     public ArrayList<ArrayList<Double>> history = new ArrayList<>();
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/Intake.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/Intake.java
@@ -6,6 +6,15 @@ import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * This runs the intake system.
+ * <p>
+ * Connections: A motor in port 0 and a controller.
+ * <p>
+ * Controls: Press dpad up to turn on the intake.
+ * <p>
+ * @param <motorPower>
+ */
 public class Intake<motorPower> extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/IntakeBeltTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/IntakeBeltTest.java
@@ -5,6 +5,14 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 import org.firstinspires.ftc.teamcode.internals.telemetry.logging.Logging;
 
+/**
+ * This tests the intake system.
+ * <p>
+ * Connections: A motor in port 0 and a controller.
+ * <p>
+ * Controls: Hold the right trigger to increase the intake speed, left trigger to decrese it, or
+ * left bumper to stop it.
+ */
 public class IntakeBeltTest extends OperationMode implements TeleOperation {
 
     double intakeSpeed = 0;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
@@ -4,6 +4,10 @@ import org.firstinspires.ftc.teamcode.features.Lifter;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Test the robot screw lifter feature.
+ * Uses controller1 and motor0.
+ */
 public class LifterTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
@@ -5,8 +5,9 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
 /**
- * Test the robot screw lifter feature.
- * Uses controller1 and motor0.
+ * This tests the robot screw lifter.
+ * <p>
+ * Features: @see Lifter
  */
 public class LifterTest extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LifterTest.java
@@ -7,7 +7,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 /**
  * This tests the robot screw lifter.
  * <p>
- * Features: @see Lifter
+ * Features: {@link org.firstinspires.ftc.teamcode.features.Lifter}
  */
 public class LifterTest extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
@@ -7,7 +7,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 /**
  * This tests the linear slide.
  * <p>
- * Features: @see LinearSlide
+ * Features: {@link org.firstinspires.ftc.teamcode.features.LinearSlide}
  */
 public class LinearSlideTest extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
@@ -5,8 +5,9 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
 /**
- * Test the linear slide feature.
- * Uses motor4 (controller1 trigger buttons) and motor5 (controller1 right stick y axis).
+ * This tests the linear slide.
+ * <p>
+ * Features: @see LinearSlide
  */
 public class LinearSlideTest extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/LinearSlideTest.java
@@ -4,6 +4,10 @@ import org.firstinspires.ftc.teamcode.features.LinearSlide;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Test the linear slide feature.
+ * Uses motor4 (controller1 trigger buttons) and motor5 (controller1 right stick y axis).
+ */
 public class LinearSlideTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
@@ -7,7 +7,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 /**
  * This tests the manual pixel grabber.
  * <p>
- * Features: @see PixelGrabber
+ * Features: {@link org.firstinspires.ftc.teamcode.features.PixelGrabber}
  */
 public class PixelGrabberTest extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
@@ -4,6 +4,10 @@ import org.firstinspires.ftc.teamcode.features.PixelGrabber;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Tests the manual pixel grabber.
+ * Uses controller1's left and right bumpers to control servo0 and servo1.
+ */
 public class PixelGrabberTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/PixelGrabberTest.java
@@ -5,8 +5,9 @@ import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
 /**
- * Tests the manual pixel grabber.
- * Uses controller1's left and right bumpers to control servo0 and servo1.
+ * This tests the manual pixel grabber.
+ * <p>
+ * Features: @see PixelGrabber
  */
 public class PixelGrabberTest extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SimpleMecanumBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SimpleMecanumBot.java
@@ -4,6 +4,11 @@ import org.firstinspires.ftc.teamcode.features.NativeMecanumDrivetrain;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * This tests the native mecanum drivetrain.
+ * <p>
+ * Features: @see NativeMecanumDrivetrain
+ */
 public class SimpleMecanumBot extends OperationMode implements TeleOperation {
     @Override
     public void construct() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SimpleMecanumBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SimpleMecanumBot.java
@@ -7,7 +7,7 @@ import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 /**
  * This tests the native mecanum drivetrain.
  * <p>
- * Features: @see NativeMecanumDrivetrain
+ * Features: {@link org.firstinspires.ftc.teamcode.features.NativeMecanumDrivetrain}
  */
 public class SimpleMecanumBot extends OperationMode implements TeleOperation {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SingleMotorTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/SingleMotorTest.java
@@ -4,6 +4,9 @@ import org.firstinspires.ftc.teamcode.internals.hardware.Devices;
 import org.firstinspires.ftc.teamcode.internals.registration.OperationMode;
 import org.firstinspires.ftc.teamcode.internals.registration.TeleOperation;
 
+/**
+ * Tests running a single motor0 with controller1's left and right trigger buttons.
+ */
 public class SingleMotorTest extends OperationMode implements TeleOperation {
     @Override
     public void construct() {


### PR DESCRIPTION
I will add documentation comments to the opmodes and features.

I think each opmode comment should have a short description and links to the features used, and each feature comment should have a short description, requirements for attached devices, and controls.