### PR TITLE
Create an action for test deployments for docs builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,25 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     allow:
-      - dependency-name: "*"
-        dependency-type: "all"
-    assignees: ["MatthewL246", "michaell4438"]
-    open-pull-requests-limit: 10
+      - dependency-name: '*'
+        dependency-type: all
+    assignees:
+      - MatthewL246
+      - michaell4438
 
-  - package-ecosystem: "gradle"
-    directory: "/"
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     allow:
-      - dependency-name: "*"
-        dependency-type: "all"
-    assignees: ["MatthewL246", "michaell4438"]
+      - dependency-name: '*'
+        dependency-type: all
+    assignees:
+      - MatthewL246
+      - michaell4438
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     assignees:
       - MatthewL246
       - michaell4438
-
     open-pull-requests-limit: 10
+
   - package-ecosystem: gradle
     directory: /
     schedule:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
-          distribution: "temurin"
-          cache: "gradle"
+          java-version: 11
+          distribution: temurin
+          cache: gradle
 
       - name: Build with Gradle
         run: ./gradlew assembleDebug --scan --stacktrace --info --no-daemon -x test
@@ -25,16 +25,17 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:
-          name: "TeamCode-debug.apk"
-          path: "TeamCode/build/outputs/apk/debug/TeamCode-debug.apk"
+          name: TeamCode-debug.apk
+          path: TeamCode/build/outputs/apk/debug/TeamCode-debug.apk
 
   release:
     runs-on: ubuntu-latest
-    needs: ["build"]
+    needs:
+      - build
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     concurrency:
-      group: "release"
-      cancel-in-progress: true
+      group: release
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository
@@ -45,7 +46,7 @@ jobs:
       - name: Download the APK artifact
         uses: actions/download-artifact@v3
         with:
-          name: "TeamCode-debug.apk"
+          name: TeamCode-debug.apk
 
       - name: Update the release tag
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -95,3 +95,27 @@ jobs:
         uses: actions/deploy-pages@v2
         with:
           artifact_name: "github-pages-deploy"
+
+  test-deploy:
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: ["build"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Pages build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: "github-pages-build"
+
+      - name: Extract Pages build artifact
+        run: |
+          mkdir pages-build
+          tar -xvf artifact.tar -C pages-build
+            - name: Cloudflare Pages GitHub Action
+
+      - name: Upload build to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: "xbhs-robotics-docs"
+          directory: "pages-build"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,24 +1,30 @@
 # Simple workflow for deploying static content to GitHub Pages
 name: Deploy static content to Pages
 
+# Before changing any of these workflow triggers, make sure you understand the if statements for each of the jobs
 on:
   # Run automatically after the Android CI release finishes
   workflow_run:
-    workflows: ["Android CI"]
-    branches: ["master"]
-    types: ["completed"]
+    workflows:
+      - Android CI
+    branches:
+      - master
+    types:
+      - completed
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   # Run on pull requests to master
   pull_request:
     # Note that this specifies the target branch, not the branch that the PR is from
-    branches: ["master"]
+    branches:
+      - master
 
 jobs:
   build:
     # Run if the Android CI build was successful, on PRs from docs/ branches, or if this is a manual workflow run
     if: ${{ github.event.workflow_run.conclusion == 'success' || startsWith(github.head_ref, 'docs/') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,9 +36,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
-          distribution: "temurin"
-          cache: "gradle"
+          java-version: 11
+          distribution: temurin
+          cache: gradle
 
       - name: Build JavaDoc using Dokka
         run: |
@@ -42,14 +48,15 @@ jobs:
       - name: Upload Pages build artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          name: "github-pages-build"
-          path: "./HelpPage/build"
+          name: github-pages-build
+          path: ./HelpPage/build
           retention-days: 90
 
   deploy:
     # Only run deployment from the master branch and not on pull requests
     if: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-    needs: ["build"]
+    needs:
+      - build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -61,8 +68,9 @@ jobs:
       id-token: write
     # Only allow one concurrent deployment
     concurrency:
-      group: "pages"
+      group: pages
       cancel-in-progress: false
+
     steps:
       - name: Configure Pages
         uses: actions/configure-pages@v3
@@ -70,7 +78,7 @@ jobs:
       - name: Download Pages build artifact
         uses: actions/download-artifact@v2
         with:
-          name: "github-pages-build"
+          name: github-pages-build
 
       - name: Extract Pages build artifact
         run: |
@@ -86,24 +94,26 @@ jobs:
       - name: Upload final Pages artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          name: "github-pages-deploy"
-          path: "./pages-build"
+          name: github-pages-deploy
+          path: ./pages-build
           retention-days: 90
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
         with:
-          artifact_name: "github-pages-deploy"
+          artifact_name: github-pages-deploy
 
   test-deploy:
-    needs: ["build"]
+    needs:
+      - build
     runs-on: ubuntu-latest
+
     steps:
       - name: Download Pages build artifact
         uses: actions/download-artifact@v2
         with:
-          name: "github-pages-build"
+          name: github-pages-build
 
       - name: Extract Pages build artifact
         run: |
@@ -116,8 +126,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: "xbhs-robotics-docs"
-          directory: "pages-build"
+          projectName: xbhs-robotics-docs
+          directory: pages-build
 
       - name: Add comment with test deployment URL
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -68,7 +68,7 @@ jobs:
       id-token: write
     # Only allow one concurrent deployment
     concurrency:
-      group: pages
+      group: pages-deploy
       cancel-in-progress: false
 
     steps:
@@ -108,6 +108,10 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    # Only allow one concurrent test deployment per branch
+    concurrency:
+      group: pages-test-deploy-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Download Pages build artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
           mv ./TeamCode/build/dokka/html ./HelpPage/build/javadoc
 
       - name: Upload Pages build artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages-build
           path: ./HelpPage/build
@@ -76,7 +76,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Download Pages build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: github-pages-build
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,7 +61,7 @@ jobs:
       id-token: write
     # Only allow one concurrent deployment
     concurrency:
-      group: "pages"
+      group: "pages-${{ github.job }}"
       cancel-in-progress: false
     steps:
       - name: Configure Pages
@@ -99,6 +99,10 @@ jobs:
   test-deploy:
     needs: ["build"]
     runs-on: ubuntu-latest
+    # Only allow one concurrent deployment
+    concurrency:
+      group: "pages-${{ github.job }}"
+      cancel-in-progress: false
     steps:
       - name: Download Pages build artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -97,7 +97,6 @@ jobs:
           artifact_name: "github-pages-deploy"
 
   test-deploy:
-    if: ${{ github.event_name == 'pull_request' }}
     needs: ["build"]
     runs-on: ubuntu-latest
     steps:
@@ -121,6 +120,7 @@ jobs:
           directory: "pages-build"
 
       - name: Add comment with test deployment URL
+        if: ${{ github.event_name == 'pull_request' }}
         run: >
           gh pr comment ${{ github.event.number }}
           --repo ${{ github.repository }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,7 +61,7 @@ jobs:
       id-token: write
     # Only allow one concurrent deployment
     concurrency:
-      group: "pages-${{ github.job }}"
+      group: "pages"
       cancel-in-progress: false
     steps:
       - name: Configure Pages
@@ -99,10 +99,6 @@ jobs:
   test-deploy:
     needs: ["build"]
     runs-on: ubuntu-latest
-    # Only allow one concurrent deployment
-    concurrency:
-      group: "pages-${{ github.job }}"
-      cancel-in-progress: false
     steps:
       - name: Download Pages build artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -110,12 +110,21 @@ jobs:
         run: |
           mkdir pages-build
           tar -xvf artifact.tar -C pages-build
-            - name: Cloudflare Pages GitHub Action
 
       - name: Upload build to Cloudflare Pages
+        id: test-deployment
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: "xbhs-robotics-docs"
           directory: "pages-build"
+
+      - name: Add comment with test deployment URL
+        run: >
+          gh pr comment ${{ github.event.number }}
+          --repo ${{ github.repository }}
+          --body "Your docs changes were built successfully!
+          View a preview of them at ${{ steps.test-deployment.outputs.url }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
           mv ./TeamCode/build/dokka/html ./HelpPage/build/javadoc
 
       - name: Upload Pages build artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v2
         with:
           name: github-pages-build
           path: ./HelpPage/build
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Download Pages build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: github-pages-build
 

--- a/HelpPage/doc/docusaurus.config.js
+++ b/HelpPage/doc/docusaurus.config.js
@@ -111,15 +111,15 @@ const config = {
             position: "right",
             items: [
               {
-                href: "https://robotics.xbhs.net/apk",
+                href: "/apk/",
                 label: "Flash Robot Controller APK"
               },
               {
-                href: "https://robotics.xbhs.net/legacy-apk",
+                href: "/legacy-apk/",
                 label: "Download Driver Station APK"
               },
               {
-                href: "https://robotics.xbhs.net/imgutil",
+                href: "/imgutil/",
                 label: "Upload Images to robotics.xbhs.com"
               },
             ]
@@ -130,15 +130,15 @@ const config = {
             position: "right",
             items: [
               {
-                href: "https://robotics.xbhs.net/javadoc",
+                href: "/javadoc/",
                 label: "Javadoc (all)"
               },
               {
-                href: "https://robotics.xbhs.net/javadoc/-team-code/org.firstinspires.ftc.teamcode.features/index.html",
+                href: "/javadoc/-team-code/org.firstinspires.ftc.teamcode.features/index.html",
                 label: "Javadoc (features)"
               },
               {
-                href: "https://robotics.xbhs.net/javadoc/-team-code/org.firstinspires.ftc.teamcode.opmodes/index.html",
+                href: "/javadoc/-team-code/org.firstinspires.ftc.teamcode.opmodes/index.html",
                 label: "Javadoc (opmodes)"
               },
             ]


### PR DESCRIPTION
**Changes:**

I created a job for the GitHub Pages action that uploads a test deployment to Cloudflare Pages. I tested this on my fork using my own Cloudflare account, see an example PR here: https://github.com/MatthewL246/FtcRobotController/pull/7.

**Controls and Usage:**

When you are making a documentation update, make sure to name your branch starting with `docs/`. After the build completes, you will receive a comment from the GitHub Actions bot on your PR with a link to a preview of the deployment.

**Required steps before merging:**

1. Someone on the XBHS Cloudflare account should set up a Cloudflare Pages project for `xbhs-robotics-docs.pages.dev`.
2. Create a secret in this repo named `CLOUDFLARE_ACCOUNT_ID ` with the account ID.
3. Create a secret in this repo named `CLOUDFLARE_API_TOKEN` with an API token that has edit access to `Account.Cloudflare Pages`.

**Reviewers:**

@XaverianTeamRobotics/senior-programmers

Closes #593.